### PR TITLE
aws-c-mqtt 0.12.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,7 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/aws-c-cal-feedstock/pr2/071091c
+  - https://staging.continuum.io/prefect/fs/aws-c-compression-feedstock/pr2/854701d
+  - https://staging.continuum.io/prefect/fs/aws-c-io-feedstock/pr2/bf28bef
+  - https://staging.continuum.io/prefect/fs/aws-c-cal-feedstock/pr2/071091c
+  - https://staging.continuum.io/prefect/fs/s2n-feedstock/pr2/9f12ab9
+  - https://staging.continuum.io/prefect/fs/aws-c-http-feedstock/pr2/36b51e2

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/aws-c-cal-feedstock/pr2/071091c
-  - https://staging.continuum.io/prefect/fs/aws-c-compression-feedstock/pr2/854701d
-  - https://staging.continuum.io/prefect/fs/aws-c-io-feedstock/pr2/bf28bef
-  - https://staging.continuum.io/prefect/fs/aws-c-cal-feedstock/pr2/071091c
-  - https://staging.continuum.io/prefect/fs/s2n-feedstock/pr2/9f12ab9
-  - https://staging.continuum.io/prefect/fs/aws-c-http-feedstock/pr2/36b51e2

--- a/recipe/0001-skip-failing-s390x-test.patch
+++ b/recipe/0001-skip-failing-s390x-test.patch
@@ -3,26 +3,18 @@ From: Marek Waszkiewicz <mwaszkiewicz@anaconda.com>
 Date: Wed, 31 Jan 2024 18:12:56 +0100
 Subject: [PATCH] skip failing s390x test
 
----
- tests/CMakeLists.txt | 5 +++--
- 1 file changed, 3 insertions(+), 2 deletions(-)
-
 diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
-index 21e961d..100ad78 100644
+index 95289f6..1e8a4e9 100644
 --- a/tests/CMakeLists.txt
 +++ b/tests/CMakeLists.txt
-@@ -40,8 +40,9 @@ add_test_case(mqtt_connection_any_publish)
- add_test_case(mqtt_connection_timeout)
- add_test_case(mqtt_connection_connack_timeout)
+@@ -58,8 +58,8 @@ add_test_case(mqtt_connection_connack_timeout)
+ add_test_case(mqtt_connection_failure_callback)
+ add_test_case(mqtt_connection_success_callback)
  add_test_case(mqtt_connect_subscribe)
 -add_test_case(mqtt_connect_subscribe_fail_from_broker)
 -add_test_case(mqtt_connect_subscribe_multi)
-+#Failing on s390x
 +#add_test_case(mqtt_connect_subscribe_fail_from_broker)
 +#add_test_case(mqtt_connect_subscribe_multi)
+ add_test_case(mqtt_connect_subscribe_incoming_dup)
  add_test_case(mqtt_connect_unsubscribe)
  add_test_case(mqtt_connect_resubscribe)
- add_test_case(mqtt_connect_publish)
--- 
-2.25.1
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.7.13" %}
+{% set version = "0.12.2" %}
 
 package:
   name: aws-c-mqtt
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/awslabs/aws-c-mqtt/archive/v{{ version }}.tar.gz
-  sha256: 04503c704f6d4fba5b0a470a01a96fa2ed702bfa897b0d38071477b0b70ccf82
+  sha256: 5707e8ddb536bc6dfc65fb16e4db8f3b9510aa187a8c5b5d59824f8a9ead7a63
   patches:                               # [s390x]
     - 0001-skip-failing-s390x-test.patch # [s390x]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,8 +7,6 @@ package:
 source:
   url: https://github.com/awslabs/aws-c-mqtt/archive/v{{ version }}.tar.gz
   sha256: 5707e8ddb536bc6dfc65fb16e4db8f3b9510aa187a8c5b5d59824f8a9ead7a63
-  patches:                               # [s390x]
-    - 0001-skip-failing-s390x-test.patch # [s390x]
 
 build:
   number: 0
@@ -20,7 +18,6 @@ requirements:
     - cmake
     - {{ compiler('c') }}
     - ninja-base
-    - patch  # [s390x]
   host:
     - aws-c-common 0.11.1
     - aws-c-io 0.17.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,9 +22,9 @@ requirements:
     - ninja-base
     - patch  # [s390x]
   host:
-    - aws-c-common 0.8.5
-    - aws-c-io 0.13.10
-    - aws-c-http 0.6.25
+    - aws-c-common 0.11.1
+    - aws-c-io 0.17.0
+    - aws-c-http 0.9.3
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,6 +7,8 @@ package:
 source:
   url: https://github.com/awslabs/aws-c-mqtt/archive/v{{ version }}.tar.gz
   sha256: 5707e8ddb536bc6dfc65fb16e4db8f3b9510aa187a8c5b5d59824f8a9ead7a63
+  patches:                               # [s390x]
+    - 0001-skip-failing-s390x-test.patch # [s390x]
 
 build:
   number: 0
@@ -18,6 +20,7 @@ requirements:
     - cmake
     - {{ compiler('c') }}
     - ninja-base
+    - patch  # [s390x]
   host:
     - aws-c-common 0.11.1
     - aws-c-io 0.17.0


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-7289](https://anaconda.atlassian.net/browse/PKG-7289) 
- [Upstream repository](https://github.com/awslabs/aws-c-mqtt/tree/v0.12.2)


### Explanation of changes:

- Update version
- Update dependencies


[PKG-7289]: https://anaconda.atlassian.net/browse/PKG-7289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ